### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/lmmx/isotarp/compare/v0.1.1...v0.1.2) - 2025-04-23
+
+### Other
+
+- release-plz initialised
+- *(lint)* happy clippy
+- type alias for test coverage
+- derive TargetMode::Per default
+- use cargo husky for git hooks
+- use just for repo tasks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "isotarp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cargo-husky",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cargo-husky = {version = "1.5.0", default-features = false, features = [
 
 [package]
 name = "isotarp"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Louis Maddox <louismmx@gmail.com>"]
 rust-version = "1.86.0"


### PR DESCRIPTION



## 🤖 New release

* `isotarp`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/lmmx/isotarp/compare/v0.1.1...v0.1.2) - 2025-04-23

### Other

- release-plz initialised
- *(lint)* happy clippy
- type alias for test coverage
- derive TargetMode::Per default
- use cargo husky for git hooks
- use just for repo tasks
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).