### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/lmmx/isotarp/compare/v0.1.2...v0.1.3) - 2025-04-23
+
+### Other
+
+- *(ci)* release binaries ([#10](https://github.com/lmmx/isotarp/pull/10))
+- use paragraphs ([#9](https://github.com/lmmx/isotarp/pull/9))
+- remove metaphor ([#7](https://github.com/lmmx/isotarp/pull/7))
+
 ## [0.1.2](https://github.com/lmmx/isotarp/compare/v0.1.1...v0.1.2) - 2025-04-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "isotarp"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "cargo-husky",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cargo-husky = {version = "1.5.0", default-features = false, features = [
 
 [package]
 name = "isotarp"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 authors = ["Louis Maddox <louismmx@gmail.com>"]
 rust-version = "1.86.0"


### PR DESCRIPTION



## 🤖 New release

* `isotarp`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/lmmx/isotarp/compare/v0.1.2...v0.1.3) - 2025-04-23

### Other

- *(ci)* release binaries ([#10](https://github.com/lmmx/isotarp/pull/10))
- use paragraphs ([#9](https://github.com/lmmx/isotarp/pull/9))
- remove metaphor ([#7](https://github.com/lmmx/isotarp/pull/7))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).