### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/lmmx/isotarp/compare/v0.1.4...v0.1.5) - 2025-04-23
+
+### Fixed
+
+- *(ci)* binaries will now release ([#13](https://github.com/lmmx/isotarp/pull/13))
+
 ## [0.1.4](https://github.com/lmmx/isotarp/compare/v0.1.3...v0.1.4) - 2025-04-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "isotarp"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "cargo-husky",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cargo-husky = {version = "1.5.0", default-features = false, features = [
 
 [package]
 name = "isotarp"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 authors = ["Louis Maddox <louismmx@gmail.com>"]
 rust-version = "1.86.0"


### PR DESCRIPTION



## 🤖 New release

* `isotarp`: 0.1.4 -> 0.1.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/lmmx/isotarp/compare/v0.1.4...v0.1.5) - 2025-04-23

### Fixed

- *(ci)* binaries will now release ([#13](https://github.com/lmmx/isotarp/pull/13))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).